### PR TITLE
builder: silence compilation warning by removing unused variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Run the setup wizard to configure bgt:
 bgt setup
 ```
 
-This will guide you through setting up your GPG key ID, signer name, and other necessary configurations.
+This will guide you through setting up your GPG key short ID, signer name, and other necessary configurations.
 
 ### Build
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,7 +20,6 @@ pub struct BuildArgs {
     pub action: BuildAction,
     pub auto: bool,
     pub tag: Option<String>,
-    pub warmup: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,7 @@ impl fmt::Display for Config {
         writeln!(f, "{:<32} {}/{}", "Detached sigs repo:", self.detached_repo_owner, self.detached_repo_name)?;
         writeln!(f, "{:<32} {:?}",  "Poll Interval:", self.poll_interval)?;
         writeln!(f, "{:<32} {}",    "Signer Name:", self.signer_name)?;
-        writeln!(f, "{:<32} {}",    "GPG Key ID:", self.gpg_key_id)?;
+        writeln!(f, "{:<32} {}",    "GPG Key Short ID:", self.gpg_key_id)?;
         writeln!(f, "{:<32} {}",    "Guix Sigs Fork URL:", self.guix_sigs_fork_url)?;
         writeln!(f, "{:<32} {}",    "Multi-package:", self.multi_package)?;
         writeln!(f, "{:<32} {:?}",  "Guix Build Directory:", self.guix_build_dir)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ async fn warmup(config: &Config) -> Result<()> {
         .context("Build process for tag warmup failed")
 }
 
-/// Check if GPG signing is possible with the given key ID
+/// Check if GPG signing is possible with the given key short ID
 fn check_gpg_signing(key_id: &str) -> Result<()> {
     use anyhow::bail;
     use std::process::Command;

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -15,14 +15,14 @@ pub(crate) async fn init_wizard() -> Result<()> {
     let default_guix_build_dir = state.join("guix-builds");
 
     let gpg_key_id =
-        prompt_input_with_validation("Enter your gpg key id (e.g. 0xA1B2C3D4E5F6G7H8)", |input| {
+        prompt_input_with_validation("Enter your gpg key short id (e.g. 0xA1B2C3D4E5F6G7H8)", |input| {
             if input.starts_with("0x") {
                 Ok(())
             } else {
-                Err("GPG key id must start with '0x'")
+                Err("GPG key short id must start with '0x'")
             }
         })
-        .context("Failed to get valid GPG key id")?;
+        .context("Failed to get valid GPG key short id")?;
 
     let signer_name =
         prompt_input("Enter your signer name").context("Failed to get signer name")?;


### PR DESCRIPTION
Really nice tool.

This is a small PR that aim to:

1. Silence Compilation Warning

   Currently, running `cargo install --path .` on the master branch produces the following warning:

   ```bash   Compiling bgt v0.1.2 (/home/abubakar-dev/bgt-builder)
   warning: field `warmup` is never read
     --> src/builder.rs:23:9
      |
   19 | pub struct BuildArgs {
      |            --------- field in this struct
   ...
   23 |     pub warmup: bool,
      |         ^^^^^^
      |
      = note: `BuildArgs` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
      = note: `#[warn(dead_code)]` on by default

   warning: `bgt` (bin "bgt") generated 1 warning
       Finished `release` profile [optimized] target(s) in 3m 59s
     Installing /root/.cargo/bin/bgt
      Installed package `bgt v0.1.2 (/home/abubakar-dev/bgt-builder)` (executable `bgt`)
   ```

   This warning can be resolved by removing the unused `warmup` field from the `BuildArgs` struct.

2. Specify we need GPG Key Short ID
The PR clarifies the requirement for the GPG key ID. I think we should explicitly specify that a short key ID should be passed GPG key Long ID are not accepted, so indicating it's short key ID thats needed will be better I think.
